### PR TITLE
Fix multiple device discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jcrummy/gosqueeze
 
-go 1.12
+go 1.22
 
 require (
 	github.com/c-bata/go-prompt v0.2.3

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -57,9 +57,9 @@ func BroadcastReceive(iface *net.Interface, sendPort int, sendMsg []byte, timeou
 	}
 	defer rconn.Close()
 
-	buf := make([]byte, 1024)
 	rconn.SetDeadline(time.Now().Add(timeout))
 	for {
+		buf := make([]byte, 1024)
 		n, addr, err := rconn.ReadFromUDP(buf)
 		if err != nil {
 			if err.(net.Error).Timeout() {


### PR DESCRIPTION
sbconfig would not work correctly if multiple devices are present on the network.

This PR fixes that, and also updates to Go 1.22.

Fixes #13 